### PR TITLE
Add Clear Port Statistics button

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,8 @@ Advanced settings include:
 
 * Set the PoE power limit ([read more](docs/services.md#set-the-poe-power-limit))
 * Set PoE settings for a specific port ([read more](docs/services.md#set-poe-settings-for-a-specific-port))
+
+
+### Clear port statistics
+
+When port statistics are supported, the integration creates a device-level **Clear port statistics** button. Pressing it clears the Tx/Rx good and bad packet counters for all ports and refreshes the displayed values immediately.

--- a/custom_components/tplink_easy_smart/button.py
+++ b/custom_components/tplink_easy_smart/button.py
@@ -1,0 +1,62 @@
+"""Button entities for TP-Link Easy Smart."""
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .client.const import FEATURE_STATS
+from .helpers import (
+    generate_entity_id,
+    generate_entity_name,
+    generate_entity_unique_id,
+    get_coordinator,
+)
+from .update_coordinator import TpLinkDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_FUNCTION_NAME = "Clear port statistics"
+_FUNCTION_UID = "clear_port_statistics"
+ENTITY_DOMAIN = "button"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up TP-Link Easy Smart buttons."""
+    coordinator: TpLinkDataUpdateCoordinator = get_coordinator(hass, config_entry)
+
+    if not await coordinator.is_feature_available(FEATURE_STATS):
+        return
+
+    async_add_entities([TpLinkClearPortStatisticsButton(coordinator)])
+
+
+class TpLinkClearPortStatisticsButton(
+    CoordinatorEntity[TpLinkDataUpdateCoordinator], ButtonEntity
+):
+    """Button that clears packet counters for every switch port."""
+
+    _attr_icon = "mdi:counter"
+
+    def __init__(self, coordinator: TpLinkDataUpdateCoordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        switch_info = coordinator.get_switch_info()
+        device_name = switch_info.name if switch_info else coordinator.name
+
+        self._attr_name = generate_entity_name(_FUNCTION_NAME, device_name)
+        self._attr_unique_id = generate_entity_unique_id(coordinator, _FUNCTION_UID)
+        self._attr_device_info = coordinator.get_device_info()
+        self.entity_id = generate_entity_id(coordinator, ENTITY_DOMAIN, _FUNCTION_NAME)
+
+    async def async_press(self) -> None:
+        """Clear all port statistics and refresh coordinator data."""
+        _LOGGER.debug("Clearing all port statistics")
+        await self.coordinator.async_clear_port_statistics()

--- a/custom_components/tplink_easy_smart/client/const.py
+++ b/custom_components/tplink_easy_smart/client/const.py
@@ -4,6 +4,7 @@ URL_DEVICE_INFO: Final = "SystemInfoRpm.htm"
 URL_PORTS_SETTINGS_GET: Final = "PortSettingRpm.htm"
 URL_POE_SETTINGS_GET: Final = "PoeConfigRpm.htm"
 URL_PORT_STATISTICS_GET: Final = "PortStatisticsRpm.htm"
+URL_PORT_STATISTICS_CLEAR: Final = "port_statistics_set.cgi"
 
 URL_PORT_SETTINGS_SET: Final = "port_setting.cgi"
 URL_POE_SETTINGS_SET: Final = "poe_global_config.cgi"

--- a/custom_components/tplink_easy_smart/client/tplink_api.py
+++ b/custom_components/tplink_easy_smart/client/tplink_api.py
@@ -25,6 +25,7 @@ from .const import (
     URL_PORT_SETTINGS_SET,
     URL_PORTS_SETTINGS_GET,
     URL_PORT_STATISTICS_GET,
+    URL_PORT_STATISTICS_CLEAR,
 )
 from .coreapi import TpLinkWebApi, VariableType
 from .utils import TpLinkFeaturesDetector
@@ -211,6 +212,14 @@ class TpLinkApi:
             result.append(state)
 
         return result
+
+    async def clear_port_statistics(self) -> None:
+        """Clear packet counters for all ports."""
+        if not await self.is_feature_available(FEATURE_STATS):
+            raise ActionError("Port statistics feature is not supported by device")
+
+        # The switch web UI submits the Clear button as a GET request.
+        await self._core_api.get(URL_PORT_STATISTICS_CLEAR, query="clear=Clear")
 
     async def get_port_poe_states(self) -> list[PortPoeState]:
         """Return the port states."""

--- a/custom_components/tplink_easy_smart/const.py
+++ b/custom_components/tplink_easy_smart/const.py
@@ -25,6 +25,7 @@ OPT_POE_STATE_SWITCHES: Final = "poe_state_switches"
 
 ATTR_MANUFACTURER: Final = "TP-Link"
 PLATFORMS: Final = [
+    Platform.BUTTON,
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,

--- a/custom_components/tplink_easy_smart/manifest.json
+++ b/custom_components/tplink_easy_smart/manifest.json
@@ -5,6 +5,7 @@
   "documentation": "https://github.com/jcalvi/hass_tplink_easy_smart",
   "issue_tracker": "https://github.com/jcalvi/hass_tplink_easy_smart/issues",
   "codeowners": [
+    "@vmakeev",
     "@jcalvi"
   ],
   "iot_class": "local_polling",

--- a/custom_components/tplink_easy_smart/update_coordinator.py
+++ b/custom_components/tplink_easy_smart/update_coordinator.py
@@ -227,6 +227,12 @@ class TpLinkDataUpdateCoordinator(DataUpdateCoordinator):
             self._port_states[index].enabled = enabled
             self.async_update_listeners()
 
+    async def async_clear_port_statistics(self) -> None:
+        """Clear all port packet counters and refresh their values."""
+        await self._api.clear_port_statistics()
+        await self._update_port_statistics()
+        self.async_update_listeners()
+
     async def async_set_poe_limit(self, limit: float) -> None:
         """Set general PoE limit."""
         await self._api.set_poe_limit(limit)


### PR DESCRIPTION
## Summary

This adds a device-level Home Assistant button equivalent to the Clear button on the switch's Port Statistics page. It allows users to reset packet counters directly from Home Assistant without opening the switch web interface.

The button uses the same endpoint as the switch web interface and refreshes
the integration immediately after the counters are cleared.

## Tested hardware

- Model: TL-SG116E
- Hardware version: 2.20
- Firmware: 1.0.0 Build 20230505 Rel.70817

## Behavior

- Clears TxGoodPkt, TxBadPkt, RxGoodPkt and RxBadPkt for all ports
- Refreshes port statistics immediately after clearing
- Preserves the existing authentication and port-statistics implementation

Issues are disabled on the repository, so this pull request is also intended
to open discussion about the feature.